### PR TITLE
Prevent a race condition? on initial page loads

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -68,9 +68,9 @@ export default class Modal extends React.Component {
   props: Props
   state: State = {}
 
-  componentWillMount() {
+  constructor() {
     const { className, children, component, stackOrder, props, onBackdropClick } = this.props;
-    this.setState({
+    this.state = {
       id: mountModal({
         component,
         children,
@@ -79,7 +79,7 @@ export default class Modal extends React.Component {
         onBackdropClick,
         className
       })
-    });
+    };
   }
 
   componentWillReceiveProps(next: Props) {


### PR DESCRIPTION
Okay not gonna lie i'm not quite sure if this is a good idea 

Thing is on a project I'm working on, when refreshing or just browsing to a route on a modal on the initial pageload `this.state.id` on line 88 will be undefined by the time the execution hits there, leaving things in an inconsistent state. This seems to fix it