### PR TITLE
Add parentPath params handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "react-test-renderer": "^15.5.4",
     "rimraf": "^2.6.1",
     "watch": "^1.0.2"
+  },
+  "dependencies": {
+    "path-to-regexp": "^2.2.1"
   }
 }

--- a/src/modal_route.js
+++ b/src/modal_route.js
@@ -2,6 +2,7 @@
 import React from 'react';  // eslint-disable-line no-unused-vars
 import { Route, withRouter } from 'react-router-dom';
 import Modal from './modal';
+import pathToRegexp from 'path-to-regexp';
 
 type Match  = { url: string, params: any }
 
@@ -82,7 +83,7 @@ function ModalRoute(routeProps: Props): any {
     if (typeof(parentPath) === 'function') {
       return parentPath(match);
     }
-    if (parentPath) return parentPath;
+    if (parentPath) return pathToRegexp(parentPath, match.params);
     if (match.params[0]) return match.params[0];
     if (match.params[0] === '') return '/';
     return match.url;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,10 +1279,6 @@ decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-diff@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-
 deep-eql@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-2.0.2.tgz#b1bac06e56f0a76777686d50c9feb75c2ed7679a"
@@ -2989,12 +2985,6 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha-fengshui-reporter@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mocha-fengshui-reporter/-/mocha-fengshui-reporter-1.1.0.tgz#8a407625b2915fcd7fbf3be647e0c19a278d1ab0"
-  dependencies:
-    deep-diff "^0.3.8"
-
 mocha@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
@@ -3347,6 +3337,10 @@ path-to-regexp@^1.5.3:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Quick and simple implementation, I'm not too familiar with your testing conventions so I'd rather leave that out for you. This uses the same implementation as `react-router`, so it shouldn't behave any differently.