### PR TITLE
bug fix: prevent Link onClick firing when modal is clicked

### DIFF
--- a/src/modal_link.js
+++ b/src/modal_link.js
@@ -53,8 +53,10 @@ function ModalLink(props: Props): any {
   } = props;
 
   return (
-    <Link to={path} className={linkClassName} tabIndex={tabIndex}>
-      {children}
+    <React.Fragment>
+      <Link to={path} className={linkClassName} tabIndex={tabIndex}>
+        {children}
+      </Link>
       <ModalRoute
         exact={exact}
         path={path}
@@ -64,7 +66,7 @@ function ModalLink(props: Props): any {
         parentPath={parentPath || match.url}
         {...getAriaProps(props)}
       />
-    </Link>
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
Hi. 

I was having issue with the onClick handler for the Link being fired when I clicked the open modal. 

This was especially a problem when I tried to use the closeModal function within the Modal since immediately after it was called, the Link onClick was also fired sending the router right back to the modal path. 

Hope this helps other people. 